### PR TITLE
Fix #11: Automated signing with actions

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,37 @@
+# .github/release-drafter.yml
+name-template: 'v$RESOLVED_VERSION'
+tag-template: 'v$RESOLVED_VERSION'
+
+version-resolver:
+  major:
+    labels: ['major']
+  minor:
+    labels: ['feature', 'enhancement']
+  patch:
+    labels: ['fix', 'bug', 'chore', 'refactor']
+  default: patch
+
+categories:
+  - title: '✨ Features'
+    labels: ['feature', 'enhancement']
+  - title: '🐛 Fixes'
+    labels: ['fix', 'bug']
+  - title: '🧹 Chores'
+    labels: ['chore', 'cleanup']
+  - title: '🧪 Tests'
+    labels: ['test']
+  - title: '📖 Documentation'
+    labels: ['docs']
+  - title: '🛠 Refactors'
+    labels: ['refactor']
+
+change-template: '- $TITLE (#$NUMBER) by @$AUTHOR'
+no-changes-template: 'No notable changes in this release.'
+
+template: |
+  ## What's Changed
+
+  $CHANGES
+
+  ## 🧑‍💻 Contributors
+  $CONTRIBUTORS

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,49 @@
+name: 📦 Publish to Maven Central
+
+on:
+  push:
+    tags:
+      - 'v*' # Triggers on tags like v0.1.0, v1.0.5, etc.
+
+jobs:
+  publish:
+    name: 🚀 Publish via GitHub Central Portal
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 17
+
+      - name: Make Gradle executable
+        run: chmod +x ./gradlew
+
+      - name: Write GPG signing properties
+        run: |
+          mkdir -p ~/.gradle
+          echo "signing.keyId=${{ secrets.SIGNING_KEY_ID }}" >> ~/.gradle/gradle.properties
+          echo "signing.password=${{ secrets.SIGNING_PASSWORD }}" >> ~/.gradle/gradle.properties
+          echo "signing.secretKeyRingFile=${{ github.workspace }}/secring.gpg" >> ~/.gradle/gradle.properties
+
+      - name: Decode GPG key to file
+        run: |
+          echo "${{ secrets.SIGNING_SECRET_KEY_RING_FILE }}" | base64 --decode > secring.gpg
+
+      - name: Publish to Maven Central
+        env:
+          RELEASE_VERSION: ${{ github.ref_name }}
+        run: ./gradlew publish --no-daemon
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: ${{ github.ref_name }}
+          body: |
+            ✅ `${{ github.ref_name }}` has been published to Maven Central!
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,20 @@
+name: 📝 Draft Release Notes
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  update-release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Generate Release Notes
+        uses: release-drafter/release-drafter@v5
+        with:
+          config-name: release-drafter.yml
+          publish: true  # 🔥 auto-publish instead of draft
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/koffee/build.gradle.kts
+++ b/koffee/build.gradle.kts
@@ -6,6 +6,9 @@ plugins {
     id("signing")
 }
 
+group = "io.github.donald-okara"
+version = System.getenv("RELEASE_VERSION") ?: "unspecified"
+
 android {
     namespace = "ke.don.koffee"
     compileSdk = 36
@@ -58,76 +61,3 @@ dependencies {
     debugImplementation(libs.androidx.ui.test.manifest)
 }
 
-afterEvaluate {
-
-    println("Signing Info:")
-    println("keyId: " + project.findProperty("signing.keyId"))
-    println("password: " + if (project.hasProperty("signing.password")) "✅" else "❌")
-    println("secretKeyRingFile: " + project.findProperty("signing.secretKeyRingFile"))
-
-    publishing {
-        publications {
-            val release by creating(MavenPublication::class) {
-                from(components["release"])
-                groupId = "com.github.donald-okara"
-                artifactId = "koffee"
-                version = "v0.1.12"
-
-                pom {
-                    name.set("Koffee")
-                    description.set("Composable toast manager for Jetpack Compose")
-                    url.set("https://github.com/donald-okara/Koffee")
-                    licenses {
-                        license {
-                            name.set("MIT License")
-                            url.set("https://opensource.org/licenses/MIT")
-                        }
-                    }
-                    developers {
-                        developer {
-                            id.set("donald-okara")
-                            name.set("Donald Okara")
-                            email.set("donaldokara123@gmail.com")
-                        }
-                    }
-                    scm {
-                        connection.set("scm:git:git://github.com/donald-okara/Koffee.git")
-                        developerConnection.set("scm:git:ssh://github.com/donald-okara/Koffee.git")
-                        url.set("https://github.com/donald-okara/Koffee")
-                    }
-                }
-            }
-        }
-
-        repositories {
-            maven {
-                name = "OSSRH"
-                url = uri("https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/")
-                credentials {
-                    username = project.findProperty("ossrhUsername")?.toString() ?: ""
-                    password = project.findProperty("ossrhPassword")?.toString() ?: ""
-                }
-            }
-        }
-    }
-
-    val shouldSign =
-        project.hasProperty("koffee.signingEnabled") &&
-            project.hasProperty("signing.keyId") &&
-            project.hasProperty("signing.password") &&
-            project.hasProperty("signing.secretKeyRingFile") &&
-            project.findProperty("koffee.signingEnabled") == "true"
-
-    if (shouldSign) {
-        signing {
-            useInMemoryPgpKeys(
-                project.findProperty("signing.keyId")!!.toString(),
-                project.findProperty("signing.password")!!.toString(),
-                file(project.findProperty("signing.secretKeyRingFile")!!).readText(),
-            )
-            sign(publishing.publications["release"])
-        }
-    } else {
-        println("⚠️ Skipping signing — missing signing config (likely JitPack build).")
-    }
-}


### PR DESCRIPTION
This commit refactors the publishing configuration in `koffee/build.gradle.kts`:
- The `group` is now set to "io.github.donald-okara".
- The `version` is now determined by the `RELEASE_VERSION` environment variable or defaults to "unspecified".
- Removed the `afterEvaluate` block that previously handled publishing and signing. This logic is now likely managed by external scripts or GitHub Actions.

New GitHub Actions workflows have been added:
- `publish.yml`: Defines a workflow to publish artifacts to Maven Central. This workflow is triggered on tags starting with 'v'. It sets up JDK, makes Gradle executable, configures GPG signing, and then publishes using `./gradlew publish`. It also creates a GitHub Release.
- `release-drafter.yml`: Defines a workflow to draft release notes. This workflow is also triggered on tags starting with 'v' and uses the `release-drafter` action to generate and publish release notes.

A `release-drafter.yml` configuration file has been added to `.github/` to customize the release drafting process, including version resolution, categories for changes, and templates.

## 📌 What does this PR do?

<!-- Describe the purpose of this PR -->

## 🧪 How was it tested?

<!-- Mention any manual/automated testing -->

## 🔨 Issue fixed

<!-- Mention The issue it fixes. Prefix with '#' -->

## 🧩 Related Issues

<!-- Link to related issues or discussions -->

## 📝 Checklist

- [ ] I have tested this change locally
- [ ] I have updated the documentation (if needed)
- [ ] I have added necessary unit tests (if needed)
- [ ] I have followed the project’s coding style
- [ ] I have run spotless checks and it passed

## 💬 Additional context

<!-- Add any other context or screenshots if relevant -->
