### PR TITLE
docs: refactor readme to include maven central implementation (Fixes #28)

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
 </p>  
 
 > 🙌 Want to contribute? Check out our [Contribution Guidelines](CONTRIBUTIONS.md).
+---  
 
 ## ✨ Features
 
@@ -23,6 +24,8 @@
 - 🔧 Customizable positioning, dismissal, durations
 - 🪶 Lightweight with zero dependencies
 
+---  
+
 ## 📱 Demo
 
 This is a demo of how Koffee works. The toasts are swipeable.
@@ -32,6 +35,8 @@ This is a demo of how Koffee works. The toasts are swipeable.
 </p>
 
 
+
+---
 ## 🛠 Installation
 
 **📦 Now available on Maven Central**
@@ -97,6 +102,7 @@ Koffee has 3 layers:
 
 You can plug in your own toast layouts, define duration policies, and limit how many are shown at once.
 
+---
 ## 🚀 Getting Started
 
 ### Step 1: Initialize Koffee
@@ -164,6 +170,7 @@ Button(
     Text("Show Success")  
 }
 ```
+---  
 
 ## 🔧 Customization
 


### PR DESCRIPTION
- docs: Update README for Maven Central distribution
- docs: Update Maven Central badge in README
- docs: Remove redundant separators in README
- docs: Add horizontal rules to README

## 📌 What does this PR do?

<!-- Describe the purpose of this PR -->
Changes README to have maven central as the default method to get the library

## 🧪 How was it tested?

<!-- Mention any manual/automated testing -->
No test required

## 🔨 Issue fixed

<!-- Mention The issue it fixes. Prefix with '#' -->
Fixes #28 

## 🧩 Related Issues

<!-- Link to related issues or discussions -->

## 📝 Checklist

- [x] I have tested this change locally
- [x] I have updated the documentation (if needed)
- [x] I have added necessary unit tests (if needed)
- [x] I have followed the project’s coding style
- [x] I have run spotless checks and it passed

## 💬 Additional context

<!-- Add any other context or screenshots if relevant -->
